### PR TITLE
fix: resolve fingerprint db from executable dir and auto-download when missing

### DIFF
--- a/cmd/args.go
+++ b/cmd/args.go
@@ -95,8 +95,8 @@ var RootCmd = &cobra.Command{
             }
         }
         
-        if !config.Isconfig {
-            logger.Error("Error: Failed to load fingerprint library.You can use --update option to get fingerprint library.")
+        if err := ensureFingerprintLibrary(); err != nil {
+            logger.Error("Error: Failed to load fingerprint library from %s: %v", config.Fingerfullpath, err)
             os.Exit(1)
         }
         models.ShowFingerPrints()
@@ -119,6 +119,19 @@ var RootCmd = &cobra.Command{
             logger.Error("Error: %v", err)
         }
     },
+}
+
+func ensureFingerprintLibrary() error {
+    if config.Isconfig {
+        return nil
+    }
+
+    if _, err := os.Stat(config.Fingerfullpath); os.IsNotExist(err) {
+        logger.Warn("Fingerprint library not found at %s. Downloading it now.", config.Fingerfullpath)
+        utils.Update()
+    }
+
+    return config.LoadFingerprintConfig()
 }
 
 func init() {

--- a/config/config.go
+++ b/config/config.go
@@ -48,28 +48,55 @@ var (
     FingerUrl = "https://raw.githubusercontent.com/HackAllSec/hfinger/main/data/finger.json"
     ReleaseUrl = "https://api.github.com/repos/HackAllSec/hfinger/releases/latest"
     Fingerfile = "finger.json"
+    ExecutableDir = "."
     Fingerfullpath = filepath.Join(Datapath, Fingerfile)
     Isconfig = false
 )
 
+func resolveExecutableDir() string {
+    exePath, err := os.Executable()
+    if err != nil {
+        return "."
+    }
+
+    realPath, err := filepath.EvalSymlinks(exePath)
+    if err == nil {
+        exePath = realPath
+    }
+
+    return filepath.Dir(exePath)
+}
+
+func initRuntimePaths() {
+    ExecutableDir = resolveExecutableDir()
+    Datapath = filepath.Join(ExecutableDir, "data")
+    Fingerfullpath = filepath.Join(Datapath, Fingerfile)
+}
+
+func LoadFingerprintConfig() error {
+    initRuntimePaths()
+
+    data, readErr := os.ReadFile(Fingerfullpath)
+    if readErr != nil {
+        Config = nil
+        Isconfig = false
+        return readErr
+    }
+
+    var loadedConfig FingerprintConfig
+    if unmarshalErr := json.Unmarshal(data, &loadedConfig); unmarshalErr != nil {
+        Config = nil
+        Isconfig = false
+        return unmarshalErr
+    }
+
+    Config = &loadedConfig
+    Isconfig = true
+    return nil
+}
+
 func init() {
     once.Do(func() {
-        absPath, pathErr := filepath.Abs(Fingerfullpath)
-        if pathErr != nil {
-            return
-        }
-
-        data, readErr := os.ReadFile(absPath)
-        if readErr != nil {
-            return
-        }
-
-        var loadedConfig FingerprintConfig
-        if unmarshalErr := json.Unmarshal(data, &loadedConfig); unmarshalErr != nil {
-            return
-        }
-
-        Config = &loadedConfig
-        Isconfig = true
+        _ = LoadFingerprintConfig()
     })
 }

--- a/utils/update.go
+++ b/utils/update.go
@@ -137,7 +137,7 @@ func CheckForUpdates() {
 func Update() {
     backupPath := config.Fingerfullpath + ".bak"
 
-    err := os.MkdirAll("data", os.ModePerm)
+    err := os.MkdirAll(config.Datapath, os.ModePerm)
     if err != nil {
         return
     }
@@ -215,9 +215,9 @@ func Upgrade() {
         return
     }
 
-    tempFile := "./" + assetName
-
     exePath, _ := os.Executable()
+    exeDir := filepath.Dir(exePath)
+    tempFile := filepath.Join(exeDir, assetName)
     backupExe := exePath + ".old"
 
     // 备份当前程序
@@ -242,8 +242,8 @@ func Upgrade() {
         return
     }
 
-    // 解压 ZIP 到当前目录
-    if err := extractZip(tempFile, "./"); err != nil {
+    // 解压 ZIP 到可执行文件目录
+    if err := extractZip(tempFile, exeDir); err != nil {
         logger.Error("Error extracting ZIP: %v", err)
         _ = os.Remove(tempFile)
         _ = os.Rename(backupExe, exePath)


### PR DESCRIPTION
- load data/finger.json relative to the hfinger binary instead of cwd
- auto-download the fingerprint database when it is missing
- reload fingerprint config after download before continuing
- write update and upgrade artifacts next to the executable
